### PR TITLE
fix(data_prep): Fix error in language identification

### DIFF
--- a/data_preparation_module/data_preparation/data_preparation.py
+++ b/data_preparation_module/data_preparation/data_preparation.py
@@ -45,6 +45,7 @@ def get_sentences_for_doc(filepath: str) -> dict:
     for para in doc.paragraphs:
         paragraphs.append(para.text.strip())
         fulltext += para.text
+    fulltext = ''.join([i for i in fulltext if (i.isalpha() or i == ' ')]).lower()[0:100]
 
     try:
         lang = language_identifier.predict([fulltext])[0].iso_code


### PR DESCRIPTION
Пофиксила ошибку, когда субмодуль по определению языка текста неправильно срабатывал или выдавал 'unk'.
Это происходило из-за вспомогательных символов в тексте. Помогла очистка входного текста от всего кроме букв и пробелов и приведение к нижнему регистру.
